### PR TITLE
test(c): add C unit tests for SpawnProcessOption serialization/parsing

### DIFF
--- a/linux_spawn_helper/CMakeLists.txt
+++ b/linux_spawn_helper/CMakeLists.txt
@@ -39,6 +39,12 @@ add_executable(
         error_handling_gtest.cpp
 )
 
+add_executable(
+        spawn_process_comm_test
+        spawn_helper_comm.c
+        spawn_process_comm_test.c
+)
+
 find_program(CMAKE_OBJCOPY NAMES llvm-objcopy objcopy)
 if(NOT CMAKE_OBJCOPY)
     message(FATAL_ERROR "objcopy not found (need llvm-objcopy or objcopy)")
@@ -98,4 +104,5 @@ target_link_libraries(
 include(GoogleTest)
 if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
     gtest_discover_tests(hello_test)
+    add_test(NAME spawn_process_comm_test COMMAND spawn_process_comm_test)
 endif ()

--- a/linux_spawn_helper/spawn_process_comm_test.c
+++ b/linux_spawn_helper/spawn_process_comm_test.c
@@ -1,0 +1,93 @@
+#include "spawn_helper_comm.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void assert_string_array_equals(char *const *expected, char *const *actual) {
+    size_t i = 0;
+    for (; expected[i] != NULL; i++) {
+        assert(actual[i] != NULL);
+        assert(strcmp(expected[i], actual[i]) == 0);
+    }
+    assert(actual[i] == NULL);
+}
+
+static void test_round_trip_with_argv_only(void) {
+    struct SpawnProcessOption option = {0};
+    char *argv[] = {"arg1", "arg2", NULL};
+    option.file = "/bin/echo";
+    option.argv = argv;
+
+    const size_t size = SpawnProcessOption_bytesSize(&option);
+    assert(size > 0);
+
+    char *buffer = (char *) calloc(size, 1);
+    assert(buffer != NULL);
+    SpawnProcessOption_bytes(&option, buffer);
+
+    struct SpawnProcessOption parsed = {0};
+    assert(SpawnProcessOption_parse(&parsed, buffer) == 0);
+    assert(strcmp(parsed.file, option.file) == 0);
+    assert(parsed.cwd == NULL);
+    assert(parsed.envp == NULL);
+    assert_string_array_equals(option.argv, parsed.argv);
+
+    SpawnProcessOption_free(&parsed);
+    free(buffer);
+}
+
+static void test_round_trip_with_cwd_and_envp(void) {
+    struct SpawnProcessOption option = {0};
+    char *argv[] = {"sh", "-c", "echo ok", NULL};
+    char *envp[] = {"HOME=/tmp", "LC_ALL=C", NULL};
+    option.file = "/bin/sh";
+    option.cwd = "/tmp";
+    option.argv = argv;
+    option.envp = envp;
+
+    const size_t size = SpawnProcessOption_bytesSize(&option);
+    char *buffer = (char *) calloc(size, 1);
+    assert(buffer != NULL);
+    SpawnProcessOption_bytes(&option, buffer);
+
+    struct SpawnProcessOption parsed = {0};
+    assert(SpawnProcessOption_parse(&parsed, buffer) == 0);
+    assert(strcmp(parsed.file, option.file) == 0);
+    assert(strcmp(parsed.cwd, option.cwd) == 0);
+    assert_string_array_equals(option.argv, parsed.argv);
+    assert_string_array_equals(option.envp, parsed.envp);
+
+    SpawnProcessOption_free(&parsed);
+    free(buffer);
+}
+
+static void test_size_matches_exact_buffer_use(void) {
+    struct SpawnProcessOption option = {0};
+    char *argv[] = {"cmd", NULL};
+    option.file = "cmd";
+    option.argv = argv;
+
+    const size_t size = SpawnProcessOption_bytesSize(&option);
+    char *buffer = (char *) malloc(size);
+    assert(buffer != NULL);
+
+    SpawnProcessOption_bytes(&option, buffer);
+
+    struct SpawnProcessOption parsed = {0};
+    assert(SpawnProcessOption_parse(&parsed, buffer) == 0);
+    assert(strcmp(parsed.file, option.file) == 0);
+    assert_string_array_equals(option.argv, parsed.argv);
+
+    SpawnProcessOption_free(&parsed);
+    free(buffer);
+}
+
+int main(void) {
+    test_round_trip_with_argv_only();
+    test_round_trip_with_cwd_and_envp();
+    test_size_matches_exact_buffer_use();
+    puts("spawn_process_comm_test: all tests passed");
+    return 0;
+}


### PR DESCRIPTION
### Motivation
- Provide C-side unit coverage for `spawn_helper_comm` focusing on `SpawnProcessOption` serialization/parsing because existing tests are C++-centric and do not exercise the pure-C API.

### Description
- Add a new C test executable `spawn_process_comm_test` implementing round-trip checks for `SpawnProcessOption` including `argv`-only, `cwd + envp`, and exact-buffer-size serialization (`linux_spawn_helper/spawn_process_comm_test.c`).
- Wire the test into CMake by adding the `spawn_process_comm_test` target and registering it with CTest on Linux via `add_test` (`linux_spawn_helper/CMakeLists.txt`).
- Keep test code minimal and C-only, calling `SpawnProcessOption_bytes`, `SpawnProcessOption_parse`, and `SpawnProcessOption_free` to validate memory handling and correctness.
- Changes were committed with a GPG-signed commit.

### Testing
- Attempted CMake configure/build with `cmake -S linux_spawn_helper -B linux_spawn_helper/build`, which failed due to `FetchContent` downloading googletest being blocked by the environment (HTTP 403) so the CMake-based test discovery could not be validated.
- Built and ran the C test directly with `cc -std=gnu17 -Wall -Wextra linux_spawn_helper/spawn_helper_comm.c linux_spawn_helper/spawn_process_comm_test.c -o /tmp/spawn_process_comm_test && /tmp/spawn_process_comm_test`, which completed successfully and printed `spawn_process_comm_test: all tests passed` (exit code 0).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a18a2d93208333993ed7ce193dfb1f)